### PR TITLE
Fix module location issue on Windows

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -63,6 +63,9 @@ std::string just_path(const std::string &name)
     if (i == std::string::npos) {
         i = name.rfind('/');
     }
+    if (name.substr(0, i+1).rfind('/')) {
+        i = name.rfind('/');
+    }
     if (i == std::string::npos) {
         return std::string();
     }


### PR DESCRIPTION
Fixes issues trying to locate extension modules when more than one path separator is used in one of the Neon Paths.